### PR TITLE
Fix highlighting issues in Neovim 0.10.1

### DIFF
--- a/colors/cosme.vim
+++ b/colors/cosme.vim
@@ -5,7 +5,7 @@
 "
 " File:       cosme.vim
 " Maintainer: beikome
-" Modified:   2019-02-02 15:11+0900
+" Modified:   2024-09-29 02:50+0900
 " License:    MIT
 
 
@@ -149,6 +149,14 @@ hi! link vimHiGroup Statement
 hi! link vimHiTerm Identifier
 hi! link yamlKeyValueDelimiter Delimiter
 hi! link NvimInternalError Error
+
+if has('nvim-0.10')
+  hi! ModeMsg cterm=bold ctermfg=NONE gui=bold guifg=NONE
+  hi! CurSearch ctermbg=225 ctermfg=242 guibg=#ffd7ff guifg=#6c6c6c
+
+  hi! link NormalFloat Pmenu
+  hi! link WinSeparator VertSplit
+endif
 
 if has('nvim')
   let g:terminal_color_0 = '#303030'


### PR DESCRIPTION
Hello,

I've noticed that the highlighting in Neovim 0.10.1 is not working correctly due to some breaking changes in this version. Specifically, the floating window and vertical window separator have been affected by these changes. Therefore, I'm submitting this PR.

Here is an example of the code I used to verify the issue with floating window. You can run it on Neovim to reproduce the behavior:

```vim
let buf = nvim_create_buf(v:false, v:true)
nvim_buf_set_lines(buf, 0, -1, v:false, ['NVIM v0.10.1'])
let ui = nvim_list_uis()[0]
let win = nvim_open_win(buf, v:false, {'relative':'editor', 'row':ui.height/2, 'col':ui.width/2-8, 'border':'double', 'width':16, 'height':1})
```

Prior to the fix:
![Screenshot 2024-09-29 at 0 08 56](https://github.com/user-attachments/assets/bc5201e6-07f1-4a8b-8158-81beb949577e)

After the fix:
![Screenshot 2024-09-29 at 0 10 47](https://github.com/user-attachments/assets/75af0efb-8f27-4f25-94de-1f1b07189933)
